### PR TITLE
Fix schedule cleanup on manual broadcast

### DIFF
--- a/src/modules/ama/ama.service.ts
+++ b/src/modules/ama/ama.service.ts
@@ -308,6 +308,10 @@ export class AMAService {
     await this.knexService.knex("schedule").where({ id: scheduleId }).del();
   }
 
+  async clearSchedulesForAMA(amaId: UUID): Promise<void> {
+    await this.knexService.knex("schedule").where({ ama_id: amaId }).del();
+  }
+
   // <<------------------------------------ Analysis ------------------------------------>>
 
   async getAnalysis(
@@ -388,6 +392,7 @@ export class AMAService {
       publicGroupIds,
       this.getAMAById.bind(this),
       this.updateAMA.bind(this),
+      this.clearSchedulesForAMA.bind(this),
     );
   }
 

--- a/src/modules/ama/new-ama/broadcast-ama.ts
+++ b/src/modules/ama/new-ama/broadcast-ama.ts
@@ -12,6 +12,7 @@ export async function handleBroadcastNow(
   publicGroupIds: PublicGroupInfo,
   getAMAById: (id: UUID) => Promise<AMA | null>,
   updateAMA: (id: UUID, updates: Partial<AMA>) => Promise<boolean>,
+  clearSchedules?: (amaId: UUID) => Promise<void>,
 ): Promise<void> {
   const result = await validateIdPattern(
     ctx,
@@ -54,6 +55,11 @@ export async function handleBroadcastNow(
   await updateAMA(AMA_ID, {
     status: "broadcasted",
   });
+
+  // Remove any pending schedules for this AMA
+  if (clearSchedules) {
+    await clearSchedules(AMA_ID);
+  }
 
   await ctx.reply("Announcement Broadcasted to the group successfully!");
 


### PR DESCRIPTION
## Summary
- remove any remaining schedules after announcing an AMA manually
- provide helper to clear schedules for an AMA

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861aea20e9483319b2769df24dd0ca1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduled entries for an AMA are now automatically cleared when the AMA is broadcasted.

* **Bug Fixes**
  * Ensured that pending schedules are properly removed during the broadcast process to prevent outdated scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->