### PR TITLE
Make AMA hashtag detection case-insensitive

### DIFF
--- a/src/modules/ama/ama.service.ts
+++ b/src/modules/ama/ama.service.ts
@@ -175,7 +175,7 @@ export class AMAService {
   async getAMAsByHashtag(hashtag: string): Promise<AMA[] | []> {
     const ama = await this.knexService
       .knex<AMA>("ama")
-      .where({ hashtag })
+      .whereRaw("LOWER(hashtag) = ?", hashtag.toLowerCase())
       .orderBy("created_at", "desc");
     return ama || [];
   }
@@ -205,7 +205,7 @@ export class AMAService {
   async getAMAByHashtag(hashtag: string): Promise<AMA | null> {
     const ama = await this.knexService
       .knex<AMA>("ama")
-      .where({ hashtag })
+      .whereRaw("LOWER(hashtag) = ?", hashtag.toLowerCase())
       .first();
     return ama || null;
   }

--- a/src/modules/ama/start-ama/handle-questions.ts
+++ b/src/modules/ama/start-ama/handle-questions.ts
@@ -21,9 +21,12 @@ export async function handleAMAQuestion(
 
   if (!message || !("text" in message) || message.from.is_bot) return;
 
-  if (message.text && message.text.includes(`#${AMA_HASHTAG}`)) {
+  if (
+    message.text &&
+    message.text.toLowerCase().includes(`#${AMA_HASHTAG.toLowerCase()}`)
+  ) {
     const amaHashtagMatch = message.text.match(
-      new RegExp(`#${AMA_HASHTAG}(\\d+)`),
+      new RegExp(`#${AMA_HASHTAG}(\\d+)`, "i"),
     );
     const hashtag = amaHashtagMatch ? amaHashtagMatch[0] : null;
 


### PR DESCRIPTION
## Summary
- allow hashtag detection in `handle-questions` to ignore case
- query AMAs by hashtag using `LOWER` so that lookups are case-insensitive

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861af1f731883318731ec16a2091e34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hashtag matching to be case-insensitive throughout AMA features, ensuring consistent detection and retrieval regardless of letter case in user input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->