### PR TITLE
Remove scheduled_at column

### DIFF
--- a/src/migrations/20250617112400_create_ama_table.ts
+++ b/src/migrations/20250617112400_create_ama_table.ts
@@ -34,7 +34,6 @@ export async function up(knex: Knex): Promise<void> {
     table.string("special_guest");
     table.string("topic");
     table.string("hashtag").notNullable();
-    table.timestamp("scheduled_at");
     table.integer("thread_id");
     table.timestamps(true, true);
   });

--- a/src/modules/ama/ama.service.ts
+++ b/src/modules/ama/ama.service.ts
@@ -247,14 +247,6 @@ export class AMAService {
     return true;
   }
 
-  // Get all scheduled AMAs that are due for broadcasting
-  async getScheduledAMAsToBroadcast(now: Date): Promise<AMA[]> {
-    return this.knexService
-      .knex<AMA>("ama")
-      .whereNotNull("scheduled_at")
-      .where("scheduled_at", "<=", now)
-      .where("status", "scheduled");
-  }
 
   // Get scores for a specific AMA
   async getScoresForAMA(id: UUID): Promise<ScoreWithUser[]> {

--- a/src/modules/ama/types.d.ts
+++ b/src/modules/ama/types.d.ts
@@ -20,7 +20,6 @@ export interface AMA {
   special_guest?: string;
   topic: string;
   hashtag: string;
-  scheduled_at?: Date;
   thread_id?: number;
   created_at?: Date;
   updated_at?: Date;


### PR DESCRIPTION
## Summary
- drop `scheduled_at` column directly in the AMA table migration
- delete the obsolete migration that removed the column separately

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861ae4c52e4833183a5c293796b99ff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed scheduling-related features from the AMA module, including the scheduled time property and related methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->