### PR TITLE
Fix leaderboard flag placement

### DIFF
--- a/src/modules/ama/end-ama/helper/utils.ts
+++ b/src/modules/ama/end-ama/helper/utils.ts
@@ -110,19 +110,21 @@ export async function buildWinnerSelectionKeyboard(
     const user = scores[index];
     const { place, scoreDisplay } = getUserDisplayText(user, index);
 
-    let displayText = `${place} ${user.username}${scoreDisplay}`;
+    let flagPrefix = "";
 
     // Check if user is a past winner (if function is provided)
     if (isUserWinner) {
       try {
         const { bool: isPastWinner } = await isUserWinner(user.user_id);
         if (isPastWinner) {
-          displayText += " 🏁";
+          flagPrefix = "🏁 ";
         }
       } catch (error) {
         console.error("Error checking past winner status:", error);
       }
     }
+
+    const displayText = `${place} ${flagPrefix}${user.username}${scoreDisplay}`;
 
     // prettier-ignore
     keyboard.push([


### PR DESCRIPTION
## Summary
- show past winner flag before username in the leaderboard

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861aee600fc83319d94c7db7b3125b2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * The past winner flag emoji ("🏁") now appears before the username instead of after it in winner selection displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->