### PR TITLE
Fix winners broadcast button removal

### DIFF
--- a/src/modules/ama/end-ama/end.ama.ts
+++ b/src/modules/ama/end-ama/end.ama.ts
@@ -453,13 +453,17 @@ export async function handleWiinersBroadcast(
     },
   );
 
+  if (ctx.callbackQuery && ctx.callbackQuery.message) {
+    await ctx.editMessageReplyMarkup({ inline_keyboard: [] });
+  }
+
   if (broadcastToPublic.message_id) {
     return void ctx.reply(
       "Winners broadcasted successfully to the public group.",
     );
-  } else {
-    return void ctx.reply("Failed to broadcast winners to the public group.");
   }
+
+  return void ctx.reply("Failed to broadcast winners to the public group.");
 }
 
 export async function cancelWinnersCallback(


### PR DESCRIPTION
## Summary
- remove inline keyboard after broadcasting AMA winners

## Testing
- `npm run lint` *(fails: unsafe assignments in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_6861b62b04608331bdc7ff48e6963746

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Inline keyboard buttons are now cleared from the original message before broadcasting, ensuring a cleaner user interface in public groups.
  * Improved reliability of failure messages when broadcasting is unsuccessful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->