### PR TITLE
feat: ensure consistent winner count in leaderboard

### DIFF
--- a/src/modules/ama/end-ama/end.ama.ts
+++ b/src/modules/ama/end-ama/end.ama.ts
@@ -118,7 +118,13 @@ async function selectWinners(
     return;
   }
 
-  const keyboard = await buildWinnerSelectionKeyboard(sortedScores, ama.id, false, winCount);
+  const keyboard = await buildWinnerSelectionKeyboard(
+    sortedScores,
+    ama.id,
+    false,
+    winCount,
+    ama.winner_count,
+  );
 
   await ctx.reply(`🏆 <b>Top 10 Unique Users Scored Best for AMA #${ama.session_no}:</b>`, {
     parse_mode: "HTML",
@@ -247,7 +253,13 @@ export async function handleDiscardUser(
   const discardedUserIds = getDiscardedUserIds(ctx, id);
   const filteredScores = await getAMAFilteredScores(getScoresForAMA, id, discardedUserIds);
 
-  const keyboard = await buildWinnerSelectionKeyboard(filteredScores, ama.id, true, winCount);
+  const keyboard = await buildWinnerSelectionKeyboard(
+    filteredScores,
+    ama.id,
+    true,
+    winCount,
+    ama.winner_count,
+  );
 
   await ctx.editMessageReplyMarkup({
     inline_keyboard: keyboard,
@@ -286,7 +298,13 @@ export async function resetWinnersCallback(
   const discardedUserIds = getDiscardedUserIds(ctx, amaId);
   const filteredScores = getFilteredSortedScores(scores, discardedUserIds);
 
-  const keyboard = await buildWinnerSelectionKeyboard(filteredScores, ama.id, false, winCount);
+  const keyboard = await buildWinnerSelectionKeyboard(
+    filteredScores,
+    ama.id,
+    false,
+    winCount,
+    ama.winner_count,
+  );
 
   await ctx.editMessageReplyMarkup({
     inline_keyboard: keyboard,
@@ -325,7 +343,7 @@ export async function confirmWinnersCallback(
     return void ctx.reply("No winners found for this AMA session.");
   }
 
-  const topWinners = filteredScores.slice(0, 5); // Display top 5 only
+  const topWinners = filteredScores.slice(0, ama.winner_count);
 
   // End the AMA session
   await updateAMA(ama.id, {

--- a/src/modules/ama/end-ama/helper/utils.ts
+++ b/src/modules/ama/end-ama/helper/utils.ts
@@ -97,12 +97,15 @@ export async function buildWinnerSelectionKeyboard(
   amaId: UUID,
   showResetButton = false,
   winCount?: (userId: string) => Promise<{ wins: number }>,
+  displayCount = 10,
 ): Promise<InlineKeyboardButton[][]> {
   const keyboard: InlineKeyboardButton[][] = [];
 
+  const visibleScores = scores.slice(0, Math.min(displayCount, scores.length));
+
   // Build keyboard rows for each user
-  for (let index = 0; index < Math.min(scores.length, 10); index++) {
-    const user = scores[index];
+  for (let index = 0; index < visibleScores.length; index++) {
+    const user = visibleScores[index];
     const { place, scoreDisplay } = getUserDisplayText(user, index);
 
     let displayText = `${place} ${user.username}${scoreDisplay}`;
@@ -130,7 +133,7 @@ export async function buildWinnerSelectionKeyboard(
   // Add confirm button
   keyboard.push([
     {
-      text: `✅ Confirm top ${scores.length} winners`,
+      text: `✅ Confirm top ${visibleScores.length} winners`,
       callback_data: `${CALLBACK_ACTIONS.CONFIRM_WINNERS}_${amaId}`,
     },
   ]);
@@ -183,7 +186,7 @@ export async function getAMAFilteredScores(
 
 export function buildWinnersMessage(
   ama: AMA,
-  winners: ScoreWithUser[] ,
+  winners: ScoreWithUser[],
   includeScores: boolean = false,
 ): string {
   const sessionDate = ama.created_at ? dayjs(ama.created_at).format("MMMM D") : "Unknown Date";

--- a/src/modules/ama/end-ama/select-winners.ts
+++ b/src/modules/ama/end-ama/select-winners.ts
@@ -202,7 +202,13 @@ async function proceedWithWinnerSelection(
   }
 
   // Build keyboard for winner selection
-  const keyboard = await buildWinnerSelectionKeyboard(sortedScores, ama.id, false, winCount);
+  const keyboard = await buildWinnerSelectionKeyboard(
+    sortedScores,
+    ama.id,
+    false,
+    winCount,
+    ama.winner_count,
+  );
 
   await ctx.reply(`🏆 <b>Top 10 Unique Users Scored Best for AMA #${ama.session_no}:</b>`, {
     parse_mode: "HTML",


### PR DESCRIPTION
### **User description**
## Summary
- keep the winner button count constant by limiting display rows
- adjust winner selection to use `ama.winner_count`

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6870ef0d86e08331a8ce1b175241d34e


___

### **PR Type**
Enhancement


___

### **Description**
- Maintain consistent winner button count using `ama.winner_count`

- Limit display rows to prevent UI overflow

- Update keyboard builder to accept display count parameter

- Fix winner confirmation to use dynamic count


___

### **Changes diagram**

```mermaid
flowchart LR
  A["buildWinnerSelectionKeyboard"] --> B["Add displayCount parameter"]
  B --> C["Limit visible scores"]
  C --> D["Update confirm button text"]
  E["selectWinners"] --> F["Pass ama.winner_count"]
  G["handleDiscardUser"] --> F
  H["resetWinnersCallback"] --> F
  I["confirmWinnersCallback"] --> J["Use ama.winner_count for slice"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>end.ama.ts</strong><dd><code>Update winner selection to use dynamic count</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/modules/ama/end-ama/end.ama.ts

<li>Pass <code>ama.winner_count</code> to <code>buildWinnerSelectionKeyboard</code> in three <br>functions<br> <li> Update <code>confirmWinnersCallback</code> to use <code>ama.winner_count</code> instead of <br>hardcoded 5


</details>


  </td>
  <td><a href="https://github.com/CeyLabs/Binance-AMA-TGBot-BE/pull/30/files#diff-f2ba11a39c440e6c1606bcf8cf4b9883447091cda24ff226fd3cfdf6a1cdbb7f">+22/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>utils.ts</strong><dd><code>Add display count parameter to keyboard builder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/modules/ama/end-ama/helper/utils.ts

<li>Add <code>displayCount</code> parameter to <code>buildWinnerSelectionKeyboard</code> function<br> <li> Limit visible scores using <code>displayCount</code> instead of hardcoded 10<br> <li> Update confirm button text to show actual visible winner count<br> <li> Fix minor formatting issue in <code>buildWinnersMessage</code>


</details>


  </td>
  <td><a href="https://github.com/CeyLabs/Binance-AMA-TGBot-BE/pull/30/files#diff-e660bbe6ca7c4ae290b64ced07951916cbd7e9f81fc9a174cc246d3d264ba835">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>select-winners.ts</strong><dd><code>Use dynamic winner count in selection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/modules/ama/end-ama/select-winners.ts

- Pass `ama.winner_count` to `buildWinnerSelectionKeyboard` function


</details>


  </td>
  <td><a href="https://github.com/CeyLabs/Binance-AMA-TGBot-BE/pull/30/files#diff-305e16e82560b6cc8a3e971c2153a60c369db88e621b055b758e0761735dec20">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The number of winners displayed during AMA winner selection is now configurable per session, allowing for a dynamic and tailored experience.
* **Improvements**
  * The winner selection interface now accurately reflects the configured winner count, enhancing clarity for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->