### PR TITLE
fix: force IPv4 for Telegram API requests to avoid IPv6 egress issues

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,7 @@ import { AMAModule } from "./modules/ama/ama.module";
 import { session } from "telegraf";
 import { ScheduleModule } from "@nestjs/schedule";
 import { ScheduleServicesModule } from "./modules/schedule/schedule.module";
+import * as https from "https";
 
 // Load environment variables
 config();
@@ -54,8 +55,17 @@ config();
         if (!token) {
           throw new Error("TELEGRAM_BOT_TOKEN is not defined in the environment variables");
         }
+        // Force IPv4 for all outbound Telegram API requests to avoid IPv6 egress issues
+        const agent = new https.Agent({ family: 4 });
         return {
           token,
+          options: {
+            // Provide a custom agent with family: 4
+            telegram: {
+              agent,
+              attachmentAgent: agent
+            },
+          },
           launchOptions:
             process.env.ENABLE_WEBHOOK === "true"
               ? {


### PR DESCRIPTION
This PR adds IPv4 forcing for all outbound Telegram API requests to resolve IPv6 egress issues that may cause connection problems.

Changes:
- Added HTTPS agent with family: 4 to force IPv4 connections
- Applied agent to both telegram and attachmentAgent configurations
- Ensures reliable Telegram API connectivity by avoiding IPv6 routing issues


___

### **PR Type**
Bug fix


___

### **Description**
- Force IPv4 connections for Telegram API requests

- Add HTTPS agent configuration to avoid IPv6 issues

- Ensure reliable Telegram bot connectivity


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HTTPS Agent"] --> B["IPv4 Family Setting"]
  B --> C["Telegram Config"]
  B --> D["Attachment Agent"]
  C --> E["Reliable API Connection"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app.module.ts</strong><dd><code>Configure IPv4-only HTTPS agent for Telegram</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app.module.ts

<ul><li>Import <code>https</code> module for agent creation<br> <li> Create HTTPS agent with <code>family: 4</code> to force IPv4<br> <li> Configure Telegram module with custom agent for both <code>telegram</code> and <br><code>attachmentAgent</code><br> <li> Add detailed comments explaining IPv6 egress issue resolution</ul>


</details>


  </td>
  <td><a href="https://github.com/CeyLabs/Binance-AMA-TGBot-BE/pull/47/files#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

